### PR TITLE
Remove usethis dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     fs,
     rlang,
     targets,
-    usethis,
     withr
 Suggests: 
     testthat (>= 3.0.0)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # tarchives 0.1.2
 
+* tarchives no longer depends on usethis.
 * Tests no longer leave files in the user cache directory (`tools::R_user_dir("tarchives", "cache")`) during `R CMD check`, which caused the package to be archived on CRAN.
 
 # tarchives 0.1.1

--- a/R/use_tarchives.R
+++ b/R/use_tarchives.R
@@ -9,8 +9,23 @@
 #' @export
 use_tarchives <- function(store = targets::tar_config_get("store")) {
   fs::dir_create("inst/tarchives")
-  usethis::use_build_ignore(
-    paste0("^inst/tarchives/.*/", store, "$"),
-    escape = FALSE
-  )
+  add_build_ignore(paste0("^inst/tarchives/.*/", store, "$"))
+}
+
+add_build_ignore <- function(pattern, path = ".Rbuildignore") {
+  existing <- if (fs::file_exists(path)) {
+    readLines(path, warn = FALSE)
+  } else {
+    character()
+  }
+  if (!pattern %in% existing) {
+    writeLines(c(existing, pattern), path)
+    rlang::inform(paste0(
+      "Adding ",
+      encodeString(pattern, quote = "'"),
+      " to ",
+      encodeString(path, quote = "'")
+    ))
+  }
+  invisible(pattern)
 }

--- a/tests/testthat/test-use_tarchives.R
+++ b/tests/testthat/test-use_tarchives.R
@@ -1,0 +1,15 @@
+test_that("use_tarchives() sets up inst/tarchives and .Rbuildignore", {
+  withr::local_dir(withr::local_tempdir())
+  suppressMessages(use_tarchives())
+
+  expect_true(fs::dir_exists("inst/tarchives"))
+  expect_in("^inst/tarchives/.*/_targets$", readLines(".Rbuildignore"))
+})
+
+test_that("add_build_ignore() appends once and is idempotent", {
+  withr::local_dir(withr::local_tempdir())
+  suppressMessages(add_build_ignore("^foo$"))
+  suppressMessages(add_build_ignore("^foo$"))
+
+  expect_equal(sum(readLines(".Rbuildignore") == "^foo$"), 1L)
+})


### PR DESCRIPTION
@
## Why

`use_tarchives()` used `usethis::use_build_ignore()` only to append a single
pattern to `.Rbuildignore`. That pulled the heavy `usethis` dependency (gert,
gh, …) into every install of `tarchives` for one tiny operation.

## Changes

- Replace the call with a small internal `add_build_ignore()` helper built on
  `fs` and base R (idempotent append, with an informational message).
- Drop `usethis` from `Imports`.
- Add `tests/testthat/test-use_tarchives.R` covering `use_tarchives()` and the
  new helper.
- NEWS entry.

## Verification

- `devtools::test()` (load_all): all tests pass, 0 failures / 0 warnings.
- `R CMD check --as-cran`: dependencies / namespace / left-over files all OK.
  0 errors / 0 warnings; the 3 NOTEs are the expected `New submission` plus
  local-environment-only ones (time server, pandoc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@