### PR TITLE
Add tests for tar_target_archive()

### DIFF
--- a/tests/testthat/test-tar_target_archive.R
+++ b/tests/testthat/test-tar_target_archive.R
@@ -1,0 +1,39 @@
+targets::tar_test("tar_target_archive() reads a target from another pipeline", {
+  writeLines(
+    c(
+      "library(targets)",
+      "list(",
+      "  tarchives::tar_target_archive(",
+      "    model,",
+      "    package = 'tarchives',",
+      "    pipeline = 'example-model'",
+      "  )",
+      ")"
+    ),
+    "_targets.R"
+  )
+  targets::tar_make(reporter = "silent")
+
+  expect_s3_class(targets::tar_read(model), "lm")
+})
+
+targets::tar_test("tar_target_archive(name_archive=) reads under a new name", {
+  writeLines(
+    c(
+      "library(targets)",
+      "list(",
+      "  tarchives::tar_target_archive(",
+      "    my_model,",
+      "    package = 'tarchives',",
+      "    pipeline = 'example-model',",
+      "    name_archive = model",
+      "  )",
+      ")"
+    ),
+    "_targets.R"
+  )
+  targets::tar_make(reporter = "silent")
+
+  expect_s3_class(targets::tar_read(my_model), "lm")
+  expect_in("my_model", targets::tar_manifest()$name)
+})


### PR DESCRIPTION
@
## Why

`tar_target_archive()` is the main user-facing function, but it had no direct
test — it was only exercised indirectly when the `example-plot` pipeline builds.

## Changes

Add `tests/testthat/test-tar_target_archive.R` with end-to-end tests that:
- declare a target from another pipeline (`example-model`) and verify the
  archived value (`model`, an `lm`) is read back, and
- cover the `name_archive` argument (declaring the target under a different
  name than the archived one).

## Verification

`devtools::test()` (load_all): all tests pass (16 passing, 0 failures / 0
warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@