### PR TITLE
Fix tar_target_archive timing and add friendly store errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * `tar_manifest_archive()` lists the targets defined in an archived pipeline.
 * `tar_meta_archive()` reads the metadata of an archived pipeline's store.
 * `tar_read_archive()`, `tar_load_archive()`, and `tar_meta_archive()` now fail with an informative error when the archived store has not been built yet.
-* `tar_target_archive()` now builds and reads the archive when the target runs rather than when the target script is sourced, so inspecting a pipeline with `tar_manifest()` or `tar_visnetwork()` no longer triggers a build. The target tracks a fingerprint of the installed pipeline source, so it refreshes the data when the package providing the archive changes and is skipped otherwise.
+* `tar_target_archive()` now builds and reads the archive when the target runs rather than when the target script is sourced, so inspecting a pipeline with `tar_manifest()` or `tar_visnetwork()` no longer triggers a build. The target tracks the installed version of the package, so it refreshes the data when a new version of the package providing the archive is installed and is skipped otherwise.
 * Tests no longer leave files in the user cache directory (`tools::R_user_dir("tarchives", "cache")`) during `R CMD check`, which caused the package to be archived on CRAN.
 
 # tarchives 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * `tar_manifest_archive()` lists the targets defined in an archived pipeline.
 * `tar_meta_archive()` reads the metadata of an archived pipeline's store.
 * `tar_read_archive()`, `tar_load_archive()`, and `tar_meta_archive()` now fail with an informative error when the archived store has not been built yet.
-* `tar_target_archive()` now builds and reads the archive when the target runs rather than when the target script is sourced, so inspecting a pipeline with `tar_manifest()` or `tar_visnetwork()` no longer triggers a build, and the resulting target defaults to `cue = tar_cue(mode = "always")` so it tracks the current archive.
+* `tar_target_archive()` now builds and reads the archive when the target runs rather than when the target script is sourced, so inspecting a pipeline with `tar_manifest()` or `tar_visnetwork()` no longer triggers a build. The target tracks a fingerprint of the installed pipeline source, so it refreshes the data when the package providing the archive changes and is skipped otherwise.
 * Tests no longer leave files in the user cache directory (`tools::R_user_dir("tarchives", "cache")`) during `R CMD check`, which caused the package to be archived on CRAN.
 
 # tarchives 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * `tar_load_archive()` loads archived targets into an environment.
 * `tar_manifest_archive()` lists the targets defined in an archived pipeline.
 * `tar_meta_archive()` reads the metadata of an archived pipeline's store.
+* `tar_read_archive()`, `tar_load_archive()`, and `tar_meta_archive()` now fail with an informative error when the archived store has not been built yet.
+* `tar_target_archive()` no longer errors when it rebuilds an outdated archive while the `cue` argument is left at its default.
 * Tests no longer leave files in the user cache directory (`tools::R_user_dir("tarchives", "cache")`) during `R CMD check`, which caused the package to be archived on CRAN.
 
 # tarchives 0.1.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * `tar_manifest_archive()` lists the targets defined in an archived pipeline.
 * `tar_meta_archive()` reads the metadata of an archived pipeline's store.
 * `tar_read_archive()`, `tar_load_archive()`, and `tar_meta_archive()` now fail with an informative error when the archived store has not been built yet.
-* `tar_target_archive()` no longer errors when it rebuilds an outdated archive while the `cue` argument is left at its default.
+* `tar_target_archive()` now builds and reads the archive when the target runs rather than when the target script is sourced, so inspecting a pipeline with `tar_manifest()` or `tar_visnetwork()` no longer triggers a build, and the resulting target defaults to `cue = tar_cue(mode = "always")` so it tracks the current archive.
 * Tests no longer leave files in the user cache directory (`tools::R_user_dir("tarchives", "cache")`) during `R CMD check`, which caused the package to be archived on CRAN.
 
 # tarchives 0.1.1

--- a/R/tar_archive.R
+++ b/R/tar_archive.R
@@ -85,6 +85,27 @@ tar_archive_store <- function(
   )
 }
 
+# Abort with an actionable message when an archived store has not been built
+# yet, rather than letting `targets` fail with a less obvious error.
+check_archive_store_exists <- function(
+  store,
+  package,
+  pipeline,
+  call = caller_env()
+) {
+  if (!fs::dir_exists(store)) {
+    cli::cli_abort(
+      c(
+        "Can't find the archived store for pipeline {.val {pipeline}} of \\
+        package {.pkg {package}}.",
+        i = "Have you run {.code tar_make_archive()} for this pipeline yet?"
+      ),
+      call = call
+    )
+  }
+  invisible(store)
+}
+
 #' Function factory for archived targets
 #'
 #' @param f A function of targets package.

--- a/R/tar_archive.R
+++ b/R/tar_archive.R
@@ -106,33 +106,6 @@ check_archive_store_exists <- function(
   invisible(store)
 }
 
-# Fingerprint the installed source of an archived pipeline (package version
-# plus the contents of the pipeline directory and the shared `R/` helpers).
-# This only reads and hashes source files -- it never runs the pipeline -- so
-# it is cheap and side-effect free, and it lets a target detect when the
-# package providing the archive has changed. The cached `_targets` store is
-# excluded because it is not part of the pipeline's source.
-tar_archive_fingerprint <- function(package, pipeline, call = caller_env()) {
-  pipeline_dir <- archive_system_file(pipeline, package = package, call = call)
-  store_dir <- fs::path(pipeline_dir, "_targets")
-  dirs <- pipeline_dir
-  shared_r <- system.file("tarchives", "R", package = package)
-  if (nzchar(shared_r)) {
-    dirs <- c(dirs, shared_r)
-  }
-  files <- unlist(lapply(dirs, function(dir) {
-    as.character(fs::dir_ls(dir, recurse = TRUE, type = "file"))
-  }))
-  files <- files[!fs::path_has_parent(files, store_dir)]
-  files <- sort(unique(files))
-  pkg_root <- system.file(package = package)
-  rlang::hash(list(
-    version = as.character(utils::packageVersion(package)),
-    files = as.character(fs::path_rel(files, pkg_root)),
-    hashes = unname(tools::md5sum(files))
-  ))
-}
-
 #' Function factory for archived targets
 #'
 #' @param f A function of targets package.

--- a/R/tar_archive.R
+++ b/R/tar_archive.R
@@ -106,6 +106,33 @@ check_archive_store_exists <- function(
   invisible(store)
 }
 
+# Fingerprint the installed source of an archived pipeline (package version
+# plus the contents of the pipeline directory and the shared `R/` helpers).
+# This only reads and hashes source files -- it never runs the pipeline -- so
+# it is cheap and side-effect free, and it lets a target detect when the
+# package providing the archive has changed. The cached `_targets` store is
+# excluded because it is not part of the pipeline's source.
+tar_archive_fingerprint <- function(package, pipeline, call = caller_env()) {
+  pipeline_dir <- archive_system_file(pipeline, package = package, call = call)
+  store_dir <- fs::path(pipeline_dir, "_targets")
+  dirs <- pipeline_dir
+  shared_r <- system.file("tarchives", "R", package = package)
+  if (nzchar(shared_r)) {
+    dirs <- c(dirs, shared_r)
+  }
+  files <- unlist(lapply(dirs, function(dir) {
+    as.character(fs::dir_ls(dir, recurse = TRUE, type = "file"))
+  }))
+  files <- files[!fs::path_has_parent(files, store_dir)]
+  files <- sort(unique(files))
+  pkg_root <- system.file(package = package)
+  rlang::hash(list(
+    version = as.character(utils::packageVersion(package)),
+    files = as.character(fs::path_rel(files, pkg_root)),
+    hashes = unname(tools::md5sum(files))
+  ))
+}
+
 #' Function factory for archived targets
 #'
 #' @param f A function of targets package.

--- a/R/tar_load_archive.R
+++ b/R/tar_load_archive.R
@@ -28,6 +28,7 @@ tar_load_archive <- function(
     pipeline = pipeline,
     store = store
   )
+  check_archive_store_exists(store, package = package, pipeline = pipeline)
   meta <- meta %||%
     targets::tar_meta(
       store = store

--- a/R/tar_make_archive.R
+++ b/R/tar_make_archive.R
@@ -1,4 +1,4 @@
-#' Run an archived pipeline of targets.
+#' Run an archived pipeline of targets
 #'
 #' @param package A scalar character of the package name.
 #' @param pipeline A scalar character of the pipeline name.

--- a/R/tar_meta_archive.R
+++ b/R/tar_meta_archive.R
@@ -26,6 +26,7 @@ tar_meta_archive <- function(
     pipeline = pipeline,
     store = store
   )
+  check_archive_store_exists(store, package = package, pipeline = pipeline)
   targets::tar_meta(
     names = {{ names }},
     fields = {{ fields }},

--- a/R/tar_read_archive.R
+++ b/R/tar_read_archive.R
@@ -49,6 +49,7 @@ tar_read_archive_raw <- function(
     pipeline = pipeline,
     store = store
   )
+  check_archive_store_exists(store, package = package, pipeline = pipeline)
   meta <- meta %||%
     targets::tar_meta(
       store = store

--- a/R/tar_source_archive.R
+++ b/R/tar_source_archive.R
@@ -1,4 +1,4 @@
-#' Run archived R scripts.
+#' Run archived R scripts
 #'
 #' @param package A scalar character of the package name.
 #' @inheritParams targets::tar_source

--- a/R/tar_target_archive.R
+++ b/R/tar_target_archive.R
@@ -76,9 +76,11 @@ tar_target_archive <- function(
 #' The archive is built (if outdated) and read when the target runs, not when
 #' the target script is sourced, so inspecting the pipeline with
 #' [targets::tar_manifest()] or [targets::tar_visnetwork()] does not trigger a
-#' build. The target defaults to `cue = tar_cue(mode = "always")` so that it
-#' tracks the current archive; downstream targets still only rebuild when the
-#' value actually changes.
+#' build. The target tracks a fingerprint of the installed pipeline source
+#' (the package version and the contents of the pipeline directory and shared
+#' `R/` helpers), so it reruns and refreshes the data when the package
+#' providing the archive changes, and is skipped otherwise. Downstream targets
+#' still only rebuild when the value actually changes.
 #'
 #' @export
 tar_target_archive_raw <- function(
@@ -135,10 +137,15 @@ tar_target_archive_raw <- function(
     )
   )
 
-  # Re-run on every `tar_make()` so the target tracks the current archive.
-  # Reading is cheap and downstream targets only rebuild when the value
-  # actually changes, so an unchanged archive does not propagate work.
-  cue <- cue %||% targets::tar_cue(mode = "always")
+  # Fold a fingerprint of the installed pipeline source into the string that
+  # `targets` hashes for up-to-dateness. The target then reruns exactly when
+  # the package providing the archive changes (e.g. a new version is
+  # installed), rebuilding and rereading the data, and is skipped otherwise.
+  string <- string %||%
+    paste0(
+      paste(deparse(command), collapse = "\n"),
+      tar_archive_fingerprint(package = package, pipeline = pipeline)
+    )
   targets::tar_target_raw(
     name = name,
     command = command,

--- a/R/tar_target_archive.R
+++ b/R/tar_target_archive.R
@@ -4,8 +4,8 @@
 #' @param pipeline A scalar character of the pipeline name.
 #' @param name_archive Symbol, name of the archived target. If `NULL`, the
 #' name of the target is used. By default, `NULL`.
-#' @param ... Arguments to pass to [targets::tar_outdated()],
-#' [targets::tar_make()] or [tar_read_archive_raw()].
+#' @param ... Arguments to pass to [tar_make_archive()] or
+#' [tar_read_archive_raw()].
 #' @inheritParams targets::tar_target
 #'
 #' @inherit targets::tar_target return
@@ -73,6 +73,13 @@ tar_target_archive <- function(
 #' evaluation, whereas `tar_target_archive_raw()` takes them as character
 #' strings.
 #'
+#' The archive is built (if outdated) and read when the target runs, not when
+#' the target script is sourced, so inspecting the pipeline with
+#' [targets::tar_manifest()] or [targets::tar_visnetwork()] does not trigger a
+#' build. The target defaults to `cue = tar_cue(mode = "always")` so that it
+#' tracks the current archive; downstream targets still only rebuild when the
+#' value actually changes.
+#'
 #' @export
 tar_target_archive_raw <- function(
   name,
@@ -103,40 +110,35 @@ tar_target_archive_raw <- function(
   check_string(pipeline, allow_empty = FALSE)
   args <- rlang::list2(...)
 
-  tar_outdated_archive <- tar_archive(
-    targets::tar_outdated,
-    package = package,
-    pipeline = pipeline
-  )
-  outdated <- rlang::exec(
-    tar_outdated_archive,
-    names = name_archive,
-    !!!args[names(args) %in% rlang::fn_fmls_names(targets::tar_outdated)],
-  )
-  if (name_archive %in% outdated) {
-    # Force the target to rebuild so it re-reads the freshly built archive.
-    # `cue` defaults to `NULL`, so start from a proper `tar_cue()` object
-    # before overriding its mode instead of coercing `NULL` into a bare list.
-    cue <- cue %||% targets::tar_cue()
-    cue$mode <- "always"
-
-    rlang::exec(
-      tarchives::tar_make_archive,
+  # Build the upstream archive (if outdated) and read the target as part of the
+  # target's *command*, so the work happens at build time inside the pipeline's
+  # own process. Doing it here, rather than when `tar_target_archive()` is
+  # called, avoids triggering builds whenever `_targets.R` is merely sourced --
+  # e.g. by `tar_manifest()`, `tar_network()`, or `tar_visnetwork()`.
+  command <- rlang::call2(
+    "{",
+    rlang::call2(
+      "tar_make_archive",
       package = package,
       pipeline = pipeline,
       names = name_archive,
-      !!!args[names(args) %in% rlang::fn_fmls_names(targets::tar_make)]
+      !!!args[names(args) %in% rlang::fn_fmls_names(targets::tar_make)],
+      .ns = "tarchives"
+    ),
+    rlang::call2(
+      "tar_read_archive_raw",
+      name = name_archive,
+      package = package,
+      pipeline = pipeline,
+      !!!args[names(args) %in% rlang::fn_fmls_names(tar_read_archive_raw)],
+      .ns = "tarchives"
     )
-  }
-
-  command <- rlang::call2(
-    "tar_read_archive_raw",
-    name = name_archive,
-    package = package,
-    pipeline = pipeline,
-    !!!args[names(args) %in% rlang::fn_fmls_names(tar_read_archive_raw)],
-    .ns = "tarchives"
   )
+
+  # Re-run on every `tar_make()` so the target tracks the current archive.
+  # Reading is cheap and downstream targets only rebuild when the value
+  # actually changes, so an unchanged archive does not propagate work.
+  cue <- cue %||% targets::tar_cue(mode = "always")
   targets::tar_target_raw(
     name = name,
     command = command,

--- a/R/tar_target_archive.R
+++ b/R/tar_target_archive.R
@@ -1,4 +1,4 @@
-#' Declare a target to read an archive.
+#' Declare a target to read an archive
 #'
 #' @param package A scalar character of the package name.
 #' @param pipeline A scalar character of the pipeline name.
@@ -114,6 +114,10 @@ tar_target_archive_raw <- function(
     !!!args[names(args) %in% rlang::fn_fmls_names(targets::tar_outdated)],
   )
   if (name_archive %in% outdated) {
+    # Force the target to rebuild so it re-reads the freshly built archive.
+    # `cue` defaults to `NULL`, so start from a proper `tar_cue()` object
+    # before overriding its mode instead of coercing `NULL` into a bare list.
+    cue <- cue %||% targets::tar_cue()
     cue$mode <- "always"
 
     rlang::exec(

--- a/R/tar_target_archive.R
+++ b/R/tar_target_archive.R
@@ -76,11 +76,10 @@ tar_target_archive <- function(
 #' The archive is built (if outdated) and read when the target runs, not when
 #' the target script is sourced, so inspecting the pipeline with
 #' [targets::tar_manifest()] or [targets::tar_visnetwork()] does not trigger a
-#' build. The target tracks a fingerprint of the installed pipeline source
-#' (the package version and the contents of the pipeline directory and shared
-#' `R/` helpers), so it reruns and refreshes the data when the package
-#' providing the archive changes, and is skipped otherwise. Downstream targets
-#' still only rebuild when the value actually changes.
+#' build. The target tracks the installed version of `package`, so it reruns
+#' and refreshes the data when a new version of the package providing the
+#' archive is installed, and is skipped otherwise. Downstream targets still
+#' only rebuild when the value actually changes.
 #'
 #' @export
 tar_target_archive_raw <- function(
@@ -137,14 +136,16 @@ tar_target_archive_raw <- function(
     )
   )
 
-  # Fold a fingerprint of the installed pipeline source into the string that
-  # `targets` hashes for up-to-dateness. The target then reruns exactly when
-  # the package providing the archive changes (e.g. a new version is
-  # installed), rebuilding and rereading the data, and is skipped otherwise.
+  # Fold the installed package version into the string that `targets` hashes
+  # for up-to-dateness (the `string` argument is the mechanism `targets`
+  # provides for this). The target then reruns -- rebuilding and rereading the
+  # data -- when a new version of the package providing the archive is
+  # installed, matching the "update the data as versions are updated" model,
+  # and is skipped otherwise.
   string <- string %||%
     paste0(
       paste(deparse(command), collapse = "\n"),
-      tar_archive_fingerprint(package = package, pipeline = pipeline)
+      utils::packageVersion(package)
     )
   targets::tar_target_raw(
     name = name,

--- a/man/tar_make_archive.Rd
+++ b/man/tar_make_archive.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tar_make_archive.R
 \name{tar_make_archive}
 \alias{tar_make_archive}
-\title{Run an archived pipeline of targets.}
+\title{Run an archived pipeline of targets}
 \usage{
 tar_make_archive(
   package,
@@ -166,5 +166,5 @@ a handle to the \code{callr} background process is returned. Either way,
 the value is invisibly returned.
 }
 \description{
-Run an archived pipeline of targets.
+Run an archived pipeline of targets
 }

--- a/man/tar_source_archive.Rd
+++ b/man/tar_source_archive.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/tar_source_archive.R
 \name{tar_source_archive}
 \alias{tar_source_archive}
-\title{Run archived R scripts.}
+\title{Run archived R scripts}
 \usage{
 tar_source_archive(
   package,
@@ -30,5 +30,5 @@ before running it.}
 \code{NULL} (invisibly)
 }
 \description{
-Run archived R scripts.
+Run archived R scripts
 }

--- a/man/tar_target_archive.Rd
+++ b/man/tar_target_archive.Rd
@@ -339,9 +339,10 @@ strings.
 
 The archive is built (if outdated) and read when the target runs, not when
 the target script is sourced, so inspecting the pipeline with
-\code{\link[targets:tar_manifest]{targets::tar_manifest()}} or
-\code{\link[targets:tar_visnetwork]{targets::tar_visnetwork()}} does not trigger a
-build. The target defaults to \code{cue = tar_cue(mode = "always")} so that it
-tracks the current archive; downstream targets still only rebuild when the
-value actually changes.
+\code{\link[targets:tar_manifest]{targets::tar_manifest()}} or \code{\link[targets:tar_visnetwork]{targets::tar_visnetwork()}} does not trigger a
+build. The target tracks a fingerprint of the installed pipeline source
+(the package version and the contents of the pipeline directory and shared
+\code{R/} helpers), so it reruns and refreshes the data when the package
+providing the archive changes, and is skipped otherwise. Downstream targets
+still only rebuild when the value actually changes.
 }

--- a/man/tar_target_archive.Rd
+++ b/man/tar_target_archive.Rd
@@ -94,8 +94,8 @@ on the result to locally recreate the target's initial RNG state.}
 \item{name_archive}{Symbol, name of the archived target. If \code{NULL}, the
 name of the target is used. By default, \code{NULL}.}
 
-\item{...}{Arguments to pass to \code{\link[targets:tar_outdated]{targets::tar_outdated()}},
-\code{\link[targets:tar_make]{targets::tar_make()}} or \code{\link[=tar_read_archive_raw]{tar_read_archive_raw()}}.}
+\item{...}{Arguments to pass to \code{\link[=tar_make_archive]{tar_make_archive()}} or
+\code{\link[=tar_read_archive_raw]{tar_read_archive_raw()}}.}
 
 \item{pattern}{Code to define a dynamic branching branching for a target.
 In \code{\link[targets:tar_target]{tar_target()}}, \code{pattern} is an unevaluated expression, e.g.
@@ -336,4 +336,12 @@ Declare a target to read an archive
 \code{tar_target_archive()} captures \code{name} and \code{name_archive} with non-standard
 evaluation, whereas \code{tar_target_archive_raw()} takes them as character
 strings.
+
+The archive is built (if outdated) and read when the target runs, not when
+the target script is sourced, so inspecting the pipeline with
+\code{\link[targets:tar_manifest]{targets::tar_manifest()}} or
+\code{\link[targets:tar_visnetwork]{targets::tar_visnetwork()}} does not trigger a
+build. The target defaults to \code{cue = tar_cue(mode = "always")} so that it
+tracks the current archive; downstream targets still only rebuild when the
+value actually changes.
 }

--- a/man/tar_target_archive.Rd
+++ b/man/tar_target_archive.Rd
@@ -3,7 +3,7 @@
 \name{tar_target_archive}
 \alias{tar_target_archive}
 \alias{tar_target_archive_raw}
-\title{Declare a target to read an archive.}
+\title{Declare a target to read an archive}
 \usage{
 tar_target_archive(
   name,
@@ -330,7 +330,7 @@ just feed them to \code{\link[=list]{list()}} in your target script file
 (default: \verb{_targets.R}).
 }
 \description{
-Declare a target to read an archive.
+Declare a target to read an archive
 }
 \details{
 \code{tar_target_archive()} captures \code{name} and \code{name_archive} with non-standard

--- a/man/tar_target_archive.Rd
+++ b/man/tar_target_archive.Rd
@@ -340,9 +340,8 @@ strings.
 The archive is built (if outdated) and read when the target runs, not when
 the target script is sourced, so inspecting the pipeline with
 \code{\link[targets:tar_manifest]{targets::tar_manifest()}} or \code{\link[targets:tar_visnetwork]{targets::tar_visnetwork()}} does not trigger a
-build. The target tracks a fingerprint of the installed pipeline source
-(the package version and the contents of the pipeline directory and shared
-\code{R/} helpers), so it reruns and refreshes the data when the package
-providing the archive changes, and is skipped otherwise. Downstream targets
-still only rebuild when the value actually changes.
+build. The target tracks the installed version of \code{package}, so it reruns
+and refreshes the data when a new version of the package providing the
+archive is installed, and is skipped otherwise. Downstream targets still
+only rebuild when the value actually changes.
 }

--- a/tests/testthat/_snaps/tar_load_archive.md
+++ b/tests/testthat/_snaps/tar_load_archive.md
@@ -1,0 +1,9 @@
+# tar_load_archive() errors when the store is not built
+
+    Code
+      tar_load_archive(model, package = "tarchives", pipeline = "not-built")
+    Condition
+      Error in `tar_load_archive()`:
+      ! Can't find the archived store for pipeline "not-built" of package tarchives.
+      i Have you run `tar_make_archive()` for this pipeline yet?
+

--- a/tests/testthat/_snaps/tar_meta_archive.md
+++ b/tests/testthat/_snaps/tar_meta_archive.md
@@ -1,0 +1,9 @@
+# tar_meta_archive() errors when the store is not built
+
+    Code
+      tar_meta_archive(package = "tarchives", pipeline = "not-built")
+    Condition
+      Error in `tar_meta_archive()`:
+      ! Can't find the archived store for pipeline "not-built" of package tarchives.
+      i Have you run `tar_make_archive()` for this pipeline yet?
+

--- a/tests/testthat/_snaps/tar_read_archive.md
+++ b/tests/testthat/_snaps/tar_read_archive.md
@@ -1,0 +1,9 @@
+# tar_read_archive() errors when the store is not built
+
+    Code
+      tar_read_archive(model, package = "tarchives", pipeline = "not-built")
+    Condition
+      Error in `tar_read_archive_raw()`:
+      ! Can't find the archived store for pipeline "not-built" of package tarchives.
+      i Have you run `tar_make_archive()` for this pipeline yet?
+

--- a/tests/testthat/test-tar_load_archive.R
+++ b/tests/testthat/test-tar_load_archive.R
@@ -13,3 +13,14 @@ targets::tar_test("tar_load_archive() loads a target into an environment", {
   )
   expect_s3_class(envir$model, "lm")
 })
+
+targets::tar_test("tar_load_archive() errors when the store is not built", {
+  expect_snapshot(
+    error = TRUE,
+    tar_load_archive(
+      model,
+      package = "tarchives",
+      pipeline = "not-built"
+    )
+  )
+})

--- a/tests/testthat/test-tar_meta_archive.R
+++ b/tests/testthat/test-tar_meta_archive.R
@@ -10,3 +10,13 @@ targets::tar_test("tar_meta_archive() returns metadata", {
   )
   expect_in("model", meta$name)
 })
+
+targets::tar_test("tar_meta_archive() errors when the store is not built", {
+  expect_snapshot(
+    error = TRUE,
+    tar_meta_archive(
+      package = "tarchives",
+      pipeline = "not-built"
+    )
+  )
+})

--- a/tests/testthat/test-tar_read_archive.R
+++ b/tests/testthat/test-tar_read_archive.R
@@ -13,3 +13,14 @@ targets::tar_test("tar_read_archive() works", {
     "lm"
   )
 })
+
+targets::tar_test("tar_read_archive() errors when the store is not built", {
+  expect_snapshot(
+    error = TRUE,
+    tar_read_archive(
+      model,
+      package = "tarchives",
+      pipeline = "not-built"
+    )
+  )
+})

--- a/tests/testthat/test-tar_target_archive.R
+++ b/tests/testthat/test-tar_target_archive.R
@@ -90,3 +90,24 @@ targets::tar_test("tar_target_archive() does not build when the script is source
   expect_in("model", targets::tar_manifest()$name)
   expect_false(unname(fs::dir_exists(store)))
 })
+
+targets::tar_test("tar_target_archive() is up to date when nothing changes", {
+  writeLines(
+    c(
+      "library(targets)",
+      "list(",
+      "  tarchives::tar_target_archive(",
+      "    model,",
+      "    package = 'tarchives',",
+      "    pipeline = 'example-model'",
+      "  )",
+      ")"
+    ),
+    "_targets.R"
+  )
+  targets::tar_make(reporter = "silent")
+
+  # The target tracks the installed source, so an unchanged package leaves it
+  # up to date rather than rerunning on every `tar_make()`.
+  expect_equal(targets::tar_outdated(), character(0))
+})

--- a/tests/testthat/test-tar_target_archive.R
+++ b/tests/testthat/test-tar_target_archive.R
@@ -39,8 +39,7 @@ targets::tar_test("tar_target_archive(name_archive=) reads under a new name", {
 })
 
 targets::tar_test("tar_target_archive() rebuilds an outdated archive", {
-  # Destroy the archive so the rebuild branch runs with the default
-  # `cue = NULL`, which previously produced an invalid cue object.
+  # Destroy the archive so the target has to build it when it runs.
   tar_destroy_archive(
     package = "tarchives",
     pipeline = "example-model",
@@ -62,4 +61,32 @@ targets::tar_test("tar_target_archive() rebuilds an outdated archive", {
   targets::tar_make(reporter = "silent")
 
   expect_s3_class(targets::tar_read(model), "lm")
+})
+
+targets::tar_test("tar_target_archive() does not build when the script is sourced", {
+  tar_destroy_archive(
+    package = "tarchives",
+    pipeline = "example-model",
+    ask = FALSE
+  )
+  store <- tar_archive_store(
+    package = "tarchives",
+    pipeline = "example-model"
+  )
+  writeLines(
+    c(
+      "library(targets)",
+      "list(",
+      "  tarchives::tar_target_archive(",
+      "    model,",
+      "    package = 'tarchives',",
+      "    pipeline = 'example-model'",
+      "  )",
+      ")"
+    ),
+    "_targets.R"
+  )
+  # Sourcing the script (here via `tar_manifest()`) must not trigger a build.
+  expect_in("model", targets::tar_manifest()$name)
+  expect_false(unname(fs::dir_exists(store)))
 })

--- a/tests/testthat/test-tar_target_archive.R
+++ b/tests/testthat/test-tar_target_archive.R
@@ -37,3 +37,29 @@ targets::tar_test("tar_target_archive(name_archive=) reads under a new name", {
   expect_s3_class(targets::tar_read(my_model), "lm")
   expect_in("my_model", targets::tar_manifest()$name)
 })
+
+targets::tar_test("tar_target_archive() rebuilds an outdated archive", {
+  # Destroy the archive so the rebuild branch runs with the default
+  # `cue = NULL`, which previously produced an invalid cue object.
+  tar_destroy_archive(
+    package = "tarchives",
+    pipeline = "example-model",
+    ask = FALSE
+  )
+  writeLines(
+    c(
+      "library(targets)",
+      "list(",
+      "  tarchives::tar_target_archive(",
+      "    model,",
+      "    package = 'tarchives',",
+      "    pipeline = 'example-model'",
+      "  )",
+      ")"
+    ),
+    "_targets.R"
+  )
+  targets::tar_make(reporter = "silent")
+
+  expect_s3_class(targets::tar_read(model), "lm")
+})


### PR DESCRIPTION
## Summary

Improves `tar_target_archive()` and the read/load/meta helpers based on a review of the package's core behavior.

### `tar_target_archive()` — build at target build time, refresh on version change
Previously it ran `tar_outdated()` and `tar_make()` on the upstream archive **while `_targets.R` was being sourced**. Because sourcing also happens for `tar_manifest()`, `tar_network()`, and `tar_visnetwork()`, merely inspecting a pipeline could trigger a build. It also coerced the default `cue = NULL` into a bare list (`cue$mode <- "always"`), which `tar_target_raw()` rejects.

Now the build-and-read happens inside the target's **command**, so it runs at build time in the pipeline's own process and never fires when the script is only sourced. The target folds the installed package version into the `string` that `targets` hashes for up-to-dateness (the mechanism `targets` provides for extensions, also used by tarchetypes), so it:

- refreshes the data when a **new version** of the package providing the archive is installed (matching the "update the data as versions are updated" model), and
- is **skipped** when the version is unchanged — no per-make rebuild check.

### Friendly errors when a store is missing
`tar_read_archive()`, `tar_load_archive()`, and `tar_meta_archive()` now abort with an actionable message ("Have you run `tar_make_archive()` for this pipeline yet?") instead of a lower-level `targets` error.

### Docs
- Drop trailing periods from roxygen titles for consistency.

## Tests
- `FAIL 0 | PASS 31`.
- New tests: archive rebuild on an outdated store, no build when the script is only sourced, the target stays up to date when nothing changes, and snapshot errors for missing stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)